### PR TITLE
Custom Windfields

### DIFF
--- a/EXAMPLE_SETUP/main.py
+++ b/EXAMPLE_SETUP/main.py
@@ -21,6 +21,7 @@ Created on Wed Mar 23 09:11:26 2022
 #Standard Libraries
 import os
 import sys
+import numpy as np
 import ttrs_quicfire as qf
 
 OG_PATH = os.getcwd()
@@ -29,11 +30,11 @@ OG_PATH = os.getcwd()
 #Track path to shapefiles that exist:
 shape_paths = qf.Shapefile_Paths()
 
-#Build domain class from shape
+###Build domain class from shape
 dom = qf.dom_from_burn_plot(shape_paths, buffer=30, QF_PATH= os.path.join(OG_PATH, 'Run'))
 
-#Build FF Fuel domain
-qf_arrs = qf.build_ff_domain(dom, FF_request=False)
+###Build FF Fuel domain
+qf_arrs = qf.build_ff_domain(dom, FF_request=True)
 #Fuel breaks
 qf_arrs.build_fuelbreak() #default build 6m fuel break around the plot
 qf_arrs.build_fuelbreak(shape_paths.streams, buffer = 1)
@@ -43,11 +44,22 @@ qf_arrs.update_surface_moisture(moist_in_plot=0.07, moist_out_plot=1)
 #Modify Wetlands
 qf_arrs.mod_wetlands(fmc=0.5, bulk_density=3)
 
-#Build ignition file and windfield
+###Build ignition file and windfield
+#Wind Option 1: Manual
+speeds = [0.1, 1, 2, 3, 2, 0.1, 1, 3, 4, 2, 1, 2]
+directions = [90, 100, 95, 90, 80, 70, 75, 80, 85, 90, 95, 100]
+times = list(range(0,(300*12),300))
 avg_wind_speed = 1.5
-avg_wind_dir = 225
+avg_wind_dir = np.average(directions)
+qf_arrs.custom_windfield(speeds=speeds, dirs=directions, times=times)
 
+#Wind Option 2: Build windfield
+# avg_wind_speed = 1.5
+# avg_wind_dir = 215
+#qf_arrs.calc_normal_windfield(start_speed = avg_wind_speed, start_dir = avg_wind_dir)
+
+#Build Ignition
 qf.atv_ignition(dom, wind_dir=avg_wind_dir, line_space_chain = 2)
-qf_arrs.calc_normal_windfield(start_speed = avg_wind_speed, start_dir = avg_wind_dir)
 
+#Build QF simulation
 qf.build_qf_run(qf_arrs)

--- a/ttrs_quicfire/exceptions.py
+++ b/ttrs_quicfire/exceptions.py
@@ -1,0 +1,70 @@
+"""
+Created on Wed Jun 15 12:48:46 2022
+
+@author: cbonesteel
+"""
+class WindDirOutOfRange(Exception):
+    """
+    Exception raised when the wind direction is out of range.
+    Default range is [0, 360).
+
+    Parameters
+    ----------
+    dir - The wind direction
+    range - The wind direction range
+    message - An explanation of the error
+    """
+
+    def __init__(self, dir, range='[0, 360)', message='Wind Direction is Not in Range'):
+        self.dir = dir
+        self.range = range
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f'{self.dir} -> {self.message} {self.range}'
+
+class WindSpeedOutOfRange(Exception):
+    """
+    Exception raised when the wind speed is out of range.
+    Default range is (0,20].
+
+    Parameters
+    ----------
+    speed - The wind speed
+    range - The wind speed range
+    message - An explanation of the error
+    """
+
+    def __init__(self, speed, range='(0,20]', message='Wind Speed is Not in Range'):
+        self.speed = speed
+        self.range = range
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f'{self.speed} -> {self.message} {self.range}'
+
+class DataLengthMismatch(Exception):
+    """
+    Exception raised when two data lengths that need to match don't.
+
+    Parameters
+    ----------
+    name1 - The name of the first set of data
+    len1 - The length of the first set of data
+    name2 - The name of the second set of data
+    len2 - The length of the second set of data
+    message - An explanation of the error
+    """
+
+    def __init__(self, name1, len1, name2, len2, message='Data Lengths Do Not Match'):
+        self.name1 = name1
+        self.len1 = len1
+        self.name2 = name2
+        self.len2 = len2
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f'{self.name1} ({self.len1}), {self.name2} ({self.len2}) -> {self.message}'

--- a/ttrs_quicfire/print_inp_files.py
+++ b/ttrs_quicfire/print_inp_files.py
@@ -20,7 +20,7 @@ def main(qf_arrs):
     print_QFire_Bldg_Advanced_User_Inputs_inp()
     print_QFire_Plume_Advanced_User_Inputs_inp()
     print_QP_buildout_inp()
-    print_QUIC_fire_inp(dom)
+    print_QUIC_fire_inp(dom, wind)
     print_QU_buildings_inp()
     print_QU_fileoptions_inp()
     print_QU_metparams_inp()
@@ -191,12 +191,12 @@ def print_QP_buildout_inp():
         input_file.write("           0  ! total number of vegitative canopies\n")
 
 
-def print_QUIC_fire_inp(dom):
+def print_QUIC_fire_inp(dom, wind):
     with open('QUIC_fire.inp', 'w') as input_file:
         input_file.write("1					! Fire flag: 1 = for fire; 0 = no fire\n")
         input_file.write("222				! Random number generator: -1: use time and date, any other integer > 0 is used as the seed\n")
         input_file.write("! FIRE TIMES\n")
-        input_file.write("1488794400		! When the fire is ignited in Unix Epoch time (integer seconds since 1970/1/1 00:00:00)\n")
+        input_file.write("{}		! When the fire is ignited in Unix Epoch time (integer seconds since 1970/1/1 00:00:00)\n".format(wind.times[0]))
         input_file.write("{}    			! Total simulation time for the fire [s]\n".format(dom.sim_time))
         input_file.write("1		   		! time step for the fire simulation [s]\n")
         input_file.write("1					! Number of fire time steps done before updating the quic wind field (integer, >= 1)\n")

--- a/ttrs_quicfire/quic_fire.py
+++ b/ttrs_quicfire/quic_fire.py
@@ -211,13 +211,17 @@ class QF_Fuel_Arrays:
     
     def calc_normal_windfield(self, start_speed, start_dir, start_time=0, shift_int=300, SENSOR_HEIGHT=6.1):
         times = list(range(start_time, start_time + self.dom.sim_time + 1, shift_int))
+        if start_speed <= 0 or start_speed > 20:
+            raise WindSpeedOutOfRange(start_speed)
+        if start_dir < 0 or start_dir >= 360:
+            raise WindDirOutOfRange(start_dir)
         self.wind = WindShifts(times, start_speed, start_dir, SENSOR_HEIGHT)
 
     def custom_windfield(self, speeds, dirs, start_time=0, shift_int=300, SENSOR_HEIGHT=6.1):
         times = list(range(start_time, start_time + self.dom.sim_time + 1, shift_int))
         if len(speeds) != len(times):
             raise DataLengthMismatch('Wind Speeds', len(speeds), 'Wind Times', len(times))
-        elif len(dirs) != len(times):
+        if len(dirs) != len(times):
             raise DataLengthMismatch('Wind Directions', len(dirs), 'Wind Times', len(times))
         for speed in speeds:
             if speed <= 0 or speed > 20:

--- a/ttrs_quicfire/quic_fire.py
+++ b/ttrs_quicfire/quic_fire.py
@@ -217,8 +217,7 @@ class QF_Fuel_Arrays:
             raise WindDirOutOfRange(start_dir)
         self.wind = WindShifts(times, start_speed, start_dir, SENSOR_HEIGHT)
 
-    def custom_windfield(self, speeds, dirs, start_time=0, shift_int=300, SENSOR_HEIGHT=6.1):
-        times = list(range(start_time, start_time + self.dom.sim_time + 1, shift_int))
+    def custom_windfield(self, speeds, dirs, times, SENSOR_HEIGHT=6.1):
         if len(speeds) != len(times):
             raise DataLengthMismatch('Wind Speeds', len(speeds), 'Wind Times', len(times))
         if len(dirs) != len(times):

--- a/ttrs_quicfire/quic_fire.py
+++ b/ttrs_quicfire/quic_fire.py
@@ -209,11 +209,11 @@ class QF_Fuel_Arrays:
                     z_layer = f_arr[z,:,:]
                     z_layer[~msk] = 0
     
-    def calc_normal_windfield(self, start_speed, start_dir, shift_int=300, start_time=0):
+    def calc_normal_windfield(self, start_speed, start_dir, start_time=0, shift_int=300, SENSOR_HEIGHT=6.1):
         times = list(range(start_time, start_time + self.dom.sim_time + 1, shift_int))
-        self.wind = WindShifts(times, start_speed, start_dir)
+        self.wind = WindShifts(times, start_speed, start_dir, SENSOR_HEIGHT)
 
-    def custom_windfield(self, speeds, dirs, shift_int=300, start_time=0):
+    def custom_windfield(self, speeds, dirs, start_time=0, shift_int=300, SENSOR_HEIGHT=6.1):
         times = list(range(start_time, start_time + self.dom.sim_time + 1, shift_int))
         if len(speeds) != len(times):
             raise DataLengthMismatch('Wind Speeds', len(speeds), 'Wind Times', len(times))
@@ -225,14 +225,14 @@ class QF_Fuel_Arrays:
         for dir in dirs:
             if dir < 0 or dir >= 360:
                 raise WindDirOutOfRange(dir)
-        self.wind = WindShifts(times, speeds, dirs, build=False)
+        self.wind = WindShifts(times, speeds, dirs, SENSOR_HEIGHT, build=False)
 
 #Currently only building normal wind field around
 class WindShifts:
     """
     Class creates randomized wind field
     """
-    def __init__(self, times, speed, dir, SENSOR_HEIGHT=6.1, build=True):
+    def __init__(self, times, speed, dir, SENSOR_HEIGHT, build=True):
         self.times = times
         self.SENSOR_HEIGHT = SENSOR_HEIGHT
         if build:

--- a/ttrs_quicfire/quic_fire.py
+++ b/ttrs_quicfire/quic_fire.py
@@ -10,6 +10,7 @@ from distutils.log import debug
 import ttrs_quicfire.build_FF_domain as FF
 import ttrs_quicfire.dat_file_functions as dat
 import ttrs_quicfire.print_inp_files
+from ttrs_quicfire.exceptions import WindDirOutOfRange, WindSpeedOutOfRange, DataLengthMismatch
 
 #Standard Libraries
 #import geopandas as gpd
@@ -208,29 +209,39 @@ class QF_Fuel_Arrays:
                     z_layer = f_arr[z,:,:]
                     z_layer[~msk] = 0
     
-    def calc_normal_windfield(self, start_speed, start_dir, shift_int=300):
-        sim_time = self.dom.sim_time
-        self.wind = WindShifts(sim_time, start_speed, start_dir, shift_int)
+    def calc_normal_windfield(self, start_speed, start_dir, shift_int=300, start_time=0):
+        times = list(range(start_time, start_time + self.dom.sim_time + 1, shift_int))
+        self.wind = WindShifts(times, start_speed, start_dir)
+
+    def custom_windfield(self, speeds, dirs, shift_int=300, start_time=0):
+        times = list(range(start_time, start_time + self.dom.sim_time + 1, shift_int))
+        if len(speeds) != len(times):
+            raise DataLengthMismatch('Wind Speeds', len(speeds), 'Wind Times', len(times))
+        elif len(dirs) != len(times):
+            raise DataLengthMismatch('Wind Directions', len(dirs), 'Wind Times', len(times))
+        for speed in speeds:
+            if speed <= 0 or speed > 20:
+                raise WindSpeedOutOfRange(speed)
+        for dir in dirs:
+            if dir < 0 or dir >= 360:
+                raise WindDirOutOfRange(dir)
+        self.wind = WindShifts(times, speeds, dirs, build=False)
 
 #Currently only building normal wind field around
 class WindShifts:
     """
     Class creates randomized wind field
     """
-    def __init__(self, sim_time, start_speed, start_dir, SENSOR_HEIGHT=6.1, shift_int=300, build=True):
+    def __init__(self, times, speed, dir, SENSOR_HEIGHT=6.1, build=True):
+        self.times = times
+        self.SENSOR_HEIGHT = SENSOR_HEIGHT
         if build:
-            self.SIM_START_TIME = 1488794400
-            self.times = list(range(1488794400,1488794400+sim_time+1,shift_int))
-            self.SENSOR_HEIGHT = 6.1 #(m) = 20 ft
-            self.dirs = [start_dir]
-            self.speeds = [start_speed]
+            self.dirs = [dir]
+            self.speeds = [speed]
             self.build_wind_field(len(self.times), self.dirs, self.speeds)
-    
         else:
-            self.times = sim_time
-            self.SENSOR_HEIGHT = SENSOR_HEIGHT  #6.1 (m) = 20 ft
-            self.dirs = start_dir
-            self.speeds = start_speed
+            self.dirs = dir
+            self.speeds = speed
     
     def build_wind_field(self, num_values, dirs, speeds):
         for i in range(1,num_values):


### PR DESCRIPTION
Issue #8 

## Description
### Changes to Class ```WindShift```
The class ```WindShift``` has a simplified initialization to accomodate custom built and autogenerated wind fields. The initialization function now takes in an entire list of times instead of a start time and shift interval. This was done since the ```calc_normal_windfield``` function was taking in these values anyways. The ```SENSOR_HEIGHT``` variable was also changed to not have an inital value since again the ```calc_normal_windfield``` asks for this. Common variables between building and custom windfields were moved outside the if statement and the if statement was updated to handle data correctly between the two options.

https://github.com/QUIC-Fire-TT/ttrs_quicfire/blob/232b4bd1b834c310eaaefd913f2041eaa06cc3fb/ttrs_quicfire/quic_fire.py#L235

### Changes to Function ```calc_normal_windfield```
The ```calc_normal_windfield``` function now allows for a custom ```start_time``` and ```SENSOR_HEIGHT```. It also calculates the times list before creating a new ```WindShift``` object. The inputted start direction and speed are now checked to see if they are in range.

https://github.com/QUIC-Fire-TT/ttrs_quicfire/blob/232b4bd1b834c310eaaefd913f2041eaa06cc3fb/ttrs_quicfire/quic_fire.py#L212-L213

### New Function ```custom_windfield```
The ```custom_windfield``` is a new function and the main attraction of this update. It is very similar to the ```calc_normal_windfield``` function in variables with the exception of using entire lists for the speeds and directions. These lists can be manually typed in or imported from a csv to a list and passed in.

https://github.com/QUIC-Fire-TT/ttrs_quicfire/blob/232b4bd1b834c310eaaefd913f2041eaa06cc3fb/ttrs_quicfire/quic_fire.py#L216

The times list is also created automatically within this function. After this, several conditions are checked. The speeds and directions are checked to be in range ((0, 20] and [0, 360) respectively). Additionally, the length of the two lists are compared to the times list to ensure they are of the same length.

### New File ```exceptions.py```
The ```exceptions.py``` file is meant to store any custom exceptions for the library. This allows easy access to excpetions across library files. Three exceptions were created with this initial creation:
* ```WindDirOutOfRange``` - Used to express when a wind direction is out of range. Takes a direction and allows for a custom range or message.
* ```WindSpeedOutOfRange``` - Used to express when a wind speed is out of range. Takes a speed and allows for a custom range or message.
* ```DataLengthMismatch``` - Used to express when two lists of data are not the same length. Takes a data name and length for two lists of data and allows for a custom message.

## Motivation and Context
These changes make creating windfields more intuitive and customizable, regardless of whether the user is generating them or passing in custom data. Custom generation is more customizable with the addition of simulation start times and sensor height manipulation. Custom data has been fully implemented with the same options as the custom generation in addition to the ability to pass in wind directions and speeds directly.

This build comes with the added bonus of an exceptions file that will allow development to becomes easier in regards to handling run breaking errors.

## Test Cases
To test the new custom wind field generation. I used the following snippet of code at the end of ```main.py```
```python
speeds = [0.1, 1, 2, 3, 2, 0.1, 1, 3, 4, 2, 1, 2]
directions = [90, 100, 95, 90, 80, 70, 75, 80, 85, 90, 95, 100]
qf_arrs.custom_windfield(speeds, directions)
```
This allowed for easy manipulation of the data to test edge cases. For starters, here is a couple example exceptions from wind directions and speeds that are not in range:

```console
Traceback (most recent call last):
  File "main.py", line 53, in <module>
    qf_arrs.custom_windfield(speeds, directions)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/ttrs_quicfire/quic_fire.py", line 227, in custom_windfield
    raise WindDirOutOfRange(dir)
ttrs_quicfire.exceptions.WindDirOutOfRange: 360 -> Wind Direction is Not in Range [0, 360)
```

```console
Traceback (most recent call last):
  File "main.py", line 53, in <module>
    qf_arrs.custom_windfield(speeds, directions)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/ttrs_quicfire/quic_fire.py", line 224, in custom_windfield
    raise WindSpeedOutOfRange(speed)
ttrs_quicfire.exceptions.WindSpeedOutOfRange: 0 -> Wind Speed is Not in Range (0,20]
```

Here is an example of what happens when I add an additional datapoint to the directions list:

```console
Traceback (most recent call last):
  File "main.py", line 53, in <module>
    qf_arrs.custom_windfield(speeds, directions)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/ttrs_quicfire/quic_fire.py", line 221, in custom_windfield
    raise DataLengthMismatch('Wind Directions', len(dirs), 'Wind Times', len(times))
ttrs_quicfire.exceptions.DataLengthMismatch: Wind Directions (13), Wind Times (12) -> Data Lengths Do Not Match
```

The ```calc_normal_windfield``` function was double checked and still works as intended with the added benefit of error handling like the ```custom_windfield``` function.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings